### PR TITLE
Added trancheId, prospect_authorization document type

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2058,7 +2058,13 @@ components:
       required:
         - offerItemId
         - product
+        - trancheId
       properties:
+        trancheId:
+          type: string
+          format: uuid
+          description: Uuid of the tranche
+          example: 51b017e1-5e59-4b58-a0a0-c638c87db463
         offerItemId:
           type: string
           format: uuid
@@ -2299,6 +2305,11 @@ components:
           items:
             type: object
             properties:
+              trancheId:
+                type: string
+                format: uuid
+                description: Uuid of the tranche
+                example: 51b017e1-5e59-4b58-a0a0-c638c87db463
               productId:
                 type: string
                 format: uuid
@@ -2587,6 +2598,7 @@ components:
         - building_plan
         - survey_copy
         - cubical_calculation
+        - prospect_authorization
         - other
     # ---------
 


### PR DESCRIPTION
Currently, it is not possible to match tranches in the offer response in case if the customer has multiple tranches with the same product variation.