### PR TITLE
issue-23-expired-offer

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2243,6 +2243,10 @@ components:
           $ref: '#/components/schemas/Amount'
         validTo:
           $ref: '#/components/schemas/Date'
+        expiredPrematurely:
+          type: boolean
+          example: false
+          description: An offer may expire prematurely if value-relevant information on the dossier has been subsequently changed.
         offerItems:
           type: array
           items:


### PR DESCRIPTION
An offer may expire prematurely if value-relevant information on the dossier has been subsequently changed.